### PR TITLE
[feat] Add each key of metaData to model.prototype on sequelize.js

### DIFF
--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -39,10 +39,8 @@ const sequelize = {
     model.prototype.reload = jest.fn()
     model.prototype.set = jest.fn()
     Object.keys(modelDefn).forEach(attachProp)
-
-    model.prototype.indexes = metaData.indexes
-    model.prototype.scopes = metaData.scopes
-    model.prototype.validate = metaData.validate
+    Object.entries(metaData).forEach([key, value] => model.prototype[key] = value)
+    
     return model
   }
 }

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -39,7 +39,7 @@ const sequelize = {
     model.prototype.reload = jest.fn()
     model.prototype.set = jest.fn()
     Object.keys(modelDefn).forEach(attachProp)
-    Object.entries(metaData).forEach([key, value] => model.prototype[key] = value)
+    Object.entries(metaData).forEach(([key, value]) => model.prototype[key] = value)
     
     return model
   }


### PR DESCRIPTION
I was struggling to test if the model had the metaData.underscored as true.
This resolves, adding every metaData key with its value to the model.prototype.